### PR TITLE
Usando um string format ao invés da classe String

### DIFF
--- a/ProjetoPlantinhasFelizes/ProjetoPlantinhasFelizes.ino
+++ b/ProjetoPlantinhasFelizes/ProjetoPlantinhasFelizes.ino
@@ -95,9 +95,8 @@ void loop() {
 void sendMessage(int sensorValue) {
   WiFiClient *client;
 
-  String message = String("\"" + String(sensorValue) + "\"");
   char msg[20];
-  message.toCharArray(msg, 20);
+  sprintf(msg, "\"%4d\"", sensorValue);
 
   client = PubNub.publish(channel, msg);
 


### PR DESCRIPTION
O Julio comentou que havia algo que poderia estar causando um vazamento de memória.
Acho que vale tentar usar este código que não usa a classe String do sdk do Arduino, a implementação padrão deles é conhecida por ser um pouco problemática e pesada.